### PR TITLE
Feature/#5 2/4 - 4/4

### DIFF
--- a/todolist-acceptance-test/src/test/java/jp/co/h30/swdev/Stepdefs.java
+++ b/todolist-acceptance-test/src/test/java/jp/co/h30/swdev/Stepdefs.java
@@ -113,7 +113,7 @@ public class Stepdefs {
     }
 
 	@When("^(\\d+)件目の完了ボタンをクリックする$")
-	public void 件目の完了ボタンをクリックする(int index) throws Throwable {
+	public void _件目の完了ボタンをクリックする(int index) throws Throwable {
 		WebElement btnComplete = findElements("btn-complete").get(index - 1);
 		btnComplete.click();
 	}

--- a/todolist-acceptance-test/src/test/java/jp/co/h30/swdev/Stepdefs.java
+++ b/todolist-acceptance-test/src/test/java/jp/co/h30/swdev/Stepdefs.java
@@ -118,6 +118,19 @@ public class Stepdefs {
 		btnComplete.click();
 	}
 
+	@When("^タイトルが\"([^\"]*)\"である最初のTodoアイテムを完了する$")
+	public void タイトルが_である最初のTodoアイテムを完了する(String title) throws Throwable {
+		List<WebElement> todos = findElements("todo");
+		for (WebElement todo : todos) {
+			String actual = findElement("title", todo).getText();
+			if (actual.equals(title)) {
+				WebElement btnComplete = findElement("btn-complete", todo);
+				btnComplete.click();
+				break;
+			}
+		}
+	}
+
 	@Then("^一覧ページが表示される$")
 	public void 一覧ページが表示される() throws Exception {
 		assertEquals(LIST_URL, driver.getCurrentUrl());

--- a/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
+++ b/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
@@ -28,3 +28,13 @@ Feature: Can I complete todo?
     And 1件目の完了ボタンをクリックする
     Then 一覧ページが表示される
     And Todoアイテムが0件表示される
+
+  Scenario: 完了済みのTodoアイテムは表示されない
+    Given 一覧ページを表示する
+    And Todoアイテムは登録されていない
+    When タイトル："Fuga", 説明："Hoge", 期限："2018/10/5"のTodoアイテムを登録済み
+    And タイトル："Hoge", 説明："Fuga", 期限："2018/10/5"のTodoアイテムを登録済み
+    And タイトルが"Fuga"である最初のTodoアイテムを完了する
+    Then 一覧ページが表示される
+    And Todoアイテムが1件表示される
+    And 1件目のタイトルが"Hoge"である

--- a/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
+++ b/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
@@ -38,3 +38,11 @@ Feature: Can I complete todo?
     Then 一覧ページが表示される
     And Todoアイテムが1件表示される
     And 1件目のタイトルが"Hoge"である
+
+  Scenario: 未完了のTodoを完了すると、一覧に表示されなくなる
+    Given 一覧ページを表示する
+    And Todoアイテムは登録されていない
+    When タイトル："Hoge", 説明："Fuga", 期限："2018/10/5"のTodoアイテムを登録済み
+    And 1件目の完了ボタンをクリックする
+    Then 一覧ページが表示される
+    And Todoアイテムが0件表示される

--- a/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
+++ b/todolist-acceptance-test/src/test/resources/jp/co/h30/swdev/can_i_complete_todo.feature
@@ -46,3 +46,13 @@ Feature: Can I complete todo?
     And 1件目の完了ボタンをクリックする
     Then 一覧ページが表示される
     And Todoアイテムが0件表示される
+
+  Scenario: 内容が同じTodoのうち1つを完了しても他のTodoに影響しない
+    Given 一覧ページを表示する
+    And Todoアイテムは登録されていない
+    When タイトル："Fuga", 説明："Hoge", 期限："2018/10/5"のTodoアイテムを登録済み
+    And タイトル："Fuga", 説明："Hoge", 期限："2018/10/5"のTodoアイテムを登録済み
+    And タイトルが"Fuga"である最初のTodoアイテムを完了する
+    Then 一覧ページが表示される
+    And Todoアイテムが1件表示される
+    And 1件目のタイトルが"Fuga"である


### PR DESCRIPTION
以下の受け入れテストシナリオを追加。実装の変更不要。
- 完了済みのTodoアイテムは表示されない
- 未完了のTodoを完了すると、一覧に表示されなくなる
- 内容が同じTodoのうち1つを完了しても他のTodoに影響しない